### PR TITLE
Support Gnome Shell 3.24

### DIFF
--- a/middleclickclose@paolo.tranquilli.gmail.com/metadata.json
+++ b/middleclickclose@paolo.tranquilli.gmail.com/metadata.json
@@ -2,7 +2,7 @@
 	"shell-version": [
 		"3.5","3.6","3.8",
 		"3.10","3.12","3.14","3.16","3.18",
-		"3.20", "3.22"
+		"3.20", "3.22", "3.24"
 	],
 	"settings-schema": "org.gnome.shell.extensions.middleclickclose",
 	"uuid": "middleclickclose@paolo.tranquilli.gmail.com",


### PR DESCRIPTION
As far as I could test, the extension runs fine with the newest GNOME shell version, so I herewith propose to declare it compatible.