### PR TITLE
Add GNOME 43 support to metadata

### DIFF
--- a/middleclickclose@paolo.tranquilli.gmail.com/metadata.json
+++ b/middleclickclose@paolo.tranquilli.gmail.com/metadata.json
@@ -1,6 +1,7 @@
 {
 	"shell-version": [
-		"42"
+		"42",
+		"43"
 	],
 	"settings-schema": "org.gnome.shell.extensions.middleclickclose",
 	"gettext-domain": "org.gnome.shell.extensions.middleclickclose",


### PR DESCRIPTION
GNOME 43 was released last month and Fedora 37 is about to launch with it next week. I've tested the extension by simply adding the 43 version support to _metadata.json_ and it still works as intended.