### PR TITLE
Fix window keyboard selection

### DIFF
--- a/middleclickclose@paolo.tranquilli.gmail.com/extension.js
+++ b/middleclickclose@paolo.tranquilli.gmail.com/extension.js
@@ -54,7 +54,6 @@ var Init = class Init {
 	}
 
 	enable() {
-		this._oldDoRemoveWindow = Workspace.Workspace.prototype._doRemoveWindow;
 		this._oldAddWindowClone = Workspace.Workspace.prototype._addWindowClone;
 		this._settings = ExtensionUtils.getSettings();
 		this._oldDelay = Workspace.WINDOW_REPOSITIONING_DELAY;
@@ -100,7 +99,6 @@ var Init = class Init {
 	}
 
 	disable() {
-		Workspace.Workspace.prototype._doRemoveWindow = this._oldDoRemoveWindow;
 		Workspace.WINDOW_REPOSITIONING_DELAY = this._oldDelay;
 		Workspace.Workspace.prototype._addWindowClone = this._oldAddWindowClone;
 		this._disconnectSettings();

--- a/middleclickclose@paolo.tranquilli.gmail.com/extension.js
+++ b/middleclickclose@paolo.tranquilli.gmail.com/extension.js
@@ -54,7 +54,6 @@ var Init = class Init {
 	}
 
 	enable() {
-		this._oldActivate = WindowPreview.prototype._activate;
 		this._oldDoRemoveWindow = Workspace.Workspace.prototype._doRemoveWindow;
 		this._oldAddWindowClone = Workspace.Workspace.prototype._addWindowClone;
 		this._settings = ExtensionUtils.getSettings();
@@ -70,7 +69,7 @@ var Init = class Init {
 			if (action.get_button() == init._closeButton) {
 				this._deleteAll();
 			} else {
-				init._oldActivate.apply(this);
+				WindowPreview.prototype._activate.apply(this);
 			}
 		};
 
@@ -101,7 +100,6 @@ var Init = class Init {
 	}
 
 	disable() {
-		WindowPreview.prototype._activate = this._oldActivate;
 		Workspace.Workspace.prototype._doRemoveWindow = this._oldDoRemoveWindow;
 		Workspace.WINDOW_REPOSITIONING_DELAY = this._oldDelay;
 		Workspace.Workspace.prototype._addWindowClone = this._oldAddWindowClone;

--- a/middleclickclose@paolo.tranquilli.gmail.com/extension.js
+++ b/middleclickclose@paolo.tranquilli.gmail.com/extension.js
@@ -32,19 +32,19 @@ const Me = ExtensionUtils.getCurrentExtension();
 
 var Init = class Init {
 
-  _connectSettings() {
-    this._settingsSignals = [];
-    this._settingsSignals.push(this._settings.connect('changed::'+CLOSE_BUTTON, this._setCloseButton.bind(this)));
-    this._settingsSignals.push(this._settings.connect('changed::'+REARRANGE_DELAY, this._setRearrangeDelay.bind(this)));
+	_connectSettings() {
+		this._settingsSignals = [];
+		this._settingsSignals.push(this._settings.connect('changed::'+CLOSE_BUTTON, this._setCloseButton.bind(this)));
+		this._settingsSignals.push(this._settings.connect('changed::'+REARRANGE_DELAY, this._setRearrangeDelay.bind(this)));
 	}
 
-  _disconnectSettings() {
-    while(this._settingsSignals.length > 0) {
+	_disconnectSettings() {
+		while(this._settingsSignals.length > 0) {
 			this._settings.disconnect(this._settingsSignals.pop());
-    }
-  }
+		}
+	}
 
-  _setCloseButton() {
+	_setCloseButton() {
 		this._closeButton = this._settings.get_enum(CLOSE_BUTTON) + 1;
 	}
 

--- a/middleclickclose@paolo.tranquilli.gmail.com/extension.js
+++ b/middleclickclose@paolo.tranquilli.gmail.com/extension.js
@@ -27,6 +27,7 @@ const Workspace = imports.ui.workspace
 const WindowPreview = imports.ui.windowPreview.WindowPreview
 const Mainloop = imports.mainloop;
 const ExtensionUtils = imports.misc.extensionUtils;
+const GObject = imports.gi.GObject;
 
 const Me = ExtensionUtils.getCurrentExtension();
 
@@ -76,12 +77,19 @@ var Init = class Init {
 		// override _addWindowClone to add my event handler
 		Workspace.Workspace.prototype._addWindowClone = function(metaWindow) {
 			let clone = init._oldAddWindowClone.apply(this, [metaWindow]);
+
+			// remove default 'clicked' signal handler
+			let id = GObject.signal_handler_find(
+				clone.get_actions()[0],
+				{signalId: 'clicked'}
+			)
+			clone.get_actions()[0].disconnect(id);
+
+			// add custom 'clicked' signal handler
 			clone.get_actions()[0].connect('clicked', onClicked.bind(clone));
+
 			return clone;
 		}
-
-		// override WindowClone's _activate
-		WindowPreview.prototype._activate = () => {};
 
 		// override Workspace's _doRemoveWindow in order to put into it the
 		// parameteriseable rearrangement delay. Rather than copy the code from


### PR DESCRIPTION
Instead of overriding the [`_activate()`](https://gitlab.gnome.org/GNOME/gnome-shell/-/blob/750ade34dae296511c246dc6bb07442120141841/js/ui/windowPreview.js#L554) function, disconnect the default 'clicked' signal handler and replace it with our own.

By doing this, window keyboard selection is restored to normal. Fixes issue #18.