### PR TITLE
Add Ukrainian (uk) translation

### DIFF
--- a/src/po/uk.po
+++ b/src/po/uk.po
@@ -1,0 +1,73 @@
+# StandWithUkraine
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# Artem Prokop <artem.prokop.dev@gmail.com>, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gnome-shell-extensions-middleclickclose\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-10-22 00:00+0300\n"
+"PO-Revision-Date: 2023-10-22 00:00+0300\n"
+"Last-Translator: Artem Prokop <artem.prokop.dev@gmail.com>\n"
+"Language-Team: \n"
+"Language: uk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: src/prefs.js:30
+msgid "Left"
+msgstr "Ліва"
+
+#: src/prefs.js:31
+msgid "Middle"
+msgstr "Середня"
+
+#: src/prefs.js:32
+msgid "Right"
+msgstr "Права"
+
+#: src/prefs.js:33
+msgid "Button 4"
+msgstr "Кнопка 4"
+
+#: src/prefs.js:34
+msgid "Button 5"
+msgstr "Кнопка 5"
+
+#: src/prefs.js:35
+msgid "Button 6"
+msgstr "Кнопка 6"
+
+#: src/prefs.js:36
+msgid "Button 7"
+msgstr "Кнопка 7"
+
+#: src/prefs.js:37
+msgid "Button 8"
+msgstr "Кнопка 8"
+
+#: src/prefs.js:38
+msgid "Button 9"
+msgstr "Кнопка 9"
+
+#: src/schemas/org.gnome.shell.extensions.middleclickclose.gschema.xml:17
+msgid "Mouse button to close"
+msgstr "Кнопка миші для закриття"
+
+#: src/schemas/org.gnome.shell.extensions.middleclickclose.gschema.xml:18
+msgid "Which mouse button triggers closing in overview."
+msgstr "Яка кнопка миші закриває вікно в оверв'ю"
+
+#: src/schemas/org.gnome.shell.extensions.middleclickclose.gschema.xml:23
+msgid "Rearrange delay"
+msgstr "Затримка перерозташування"
+
+#: src/schemas/org.gnome.shell.extensions.middleclickclose.gschema.xml:24
+msgid ""
+"How much time must pass with the pointer not moving for windows in overview "
+"to rearrange after one was closed."
+msgstr ""
+"Скільки часу курсор має не рухатись щоб вікна в оверв'ю перерозташувалися"
+" після закриття вікна."

--- a/src/po/uk.po
+++ b/src/po/uk.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Language: uk\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
 #: src/prefs.js:30


### PR DESCRIPTION
Adds Ukrainian translation.

P.S. Thanks for your job!
P.P.S. Would be nice to have actual GitHub version (G45 support) on [extensions.gnome.org](https://extensions.gnome.org/)