### PR TITLE
Gnome 48

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -5,7 +5,8 @@
 	"shell-version": [
 		"45",
 		"46",
-		"47"
+		"47",
+		"48"
 	],
 	"uuid": "middleclickclose@paolo.tranquilli.gmail.com",
 	"settings-schema": "org.gnome.shell.extensions.middleclickclose",


### PR DESCRIPTION
There is no migration guide for gnome 48 extensions yet, so I'm not putting this on master yet. It'll have to wait at least until the Gnome 48 beta / feature freeze (2025-02-01).

Until then, I'm leaving this (truly gigantic) patch here.