### PR TITLE
Make build work with paths containing whitespaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,9 @@ install: pack
 	gnome-extensions install --force ${UUID}.shell-extension.zip
 
 install-system: pack
-	mkdir -p ${EXTENSION_DIR}
-	unzip -o ${UUID}.shell-extension.zip -d ${EXTENSION_DIR}
-	glib-compile-schemas ${EXTENSION_DIR}/schemas
+	mkdir -p "${EXTENSION_DIR}"
+	unzip -o ${UUID}.shell-extension.zip -d "${EXTENSION_DIR}"
+	glib-compile-schemas "${EXTENSION_DIR}/schemas"
 
 po: $(wildcard src/po/*.po)
 pot: src/po/template.pot


### PR DESCRIPTION
Noticed the build script did not work when whitespaces were present in the build path. This PR should fix the issue.